### PR TITLE
token exp/iat attributes should use seconds instead of milliseconds

### DIFF
--- a/lib/AccessToken.js
+++ b/lib/AccessToken.js
@@ -6,6 +6,7 @@ var JWT = require('anvil-connect-jwt')
   , async = require('async')
   , request = require('superagent')
   , UnauthorizedError = require('../errors/UnauthorizedError')
+  , nowSeconds = require('./time-utils.js').nowSeconds;
   ;
 
 /**
@@ -129,7 +130,7 @@ AccessToken.verify = function (token, options, callback) {
     }
 
     // expired token
-    if (claims.exp < Date.now()) {
+    if (claims.exp < nowSeconds()) {
       return callback(new UnauthorizedError({
         error:              'invalid_token',
         error_description:  'Expired access token',

--- a/lib/IDToken.js
+++ b/lib/IDToken.js
@@ -4,6 +4,7 @@
 
 var JWT          = require('anvil-connect-jwt')
   , IDTokenError = require('./IDTokenError')
+  , nowSeconds   = require('./time-utils').nowSeconds
   ;
 
 
@@ -19,7 +20,7 @@ function expires (duration) {
   };
 
   return function () {
-    return Date.now() + fromNow[duration];
+    return nowSeconds(fromNow[duration]);
   };
 }
 
@@ -54,7 +55,7 @@ var IDToken = JWT.define({
     sub:      { format: 'StringOrURI', required: true },
     aud:      { format: 'StringOrURI', required: true },
     exp:      { format: 'IntDate',     required: true, default: expires('day')  },
-    iat:      { format: 'IntDate',     required: true, default: Date.now },
+    iat:      { format: 'IntDate',     required: true, default: nowSeconds },
     nonce:    { format: 'String' },
     acr:      { format: 'String' },
     at_hash:  { format: 'String' }
@@ -104,7 +105,7 @@ IDToken.verify = function (jwt, options, callback) {
   }
 
   // expired token
-  if (claims.exp < Date.now()) {
+  if (claims.exp < nowSeconds()) {
     return callback(new IDTokenError({
       error: 'Expired token'
     }));

--- a/lib/time-utils.js
+++ b/lib/time-utils.js
@@ -1,0 +1,20 @@
+/**
+ * http://openid.net/specs/openid-connect-core-1_0.html states exp/iat times are in secs, not millis
+ *
+ * Taken from: https://github.com/christiansmith/anvil-connect/blob/master/lib/time-utils.js
+ *
+ * @param {long} deltaSecs optional delta to be added to "now", in seconds.
+ * @return {long} "now" in seconds, with deltaSecs added if it was supplied.
+ * @api private
+ */
+exports.nowSeconds = function (deltaSecs) {
+  var secs = Date.now();
+  var secs = Math.round(secs / 1000);
+  var secsStr;
+
+  if (deltaSecs) {
+    secs += deltaSecs;
+  }
+  secsStr = secs.toString();
+  return secs;
+};

--- a/test/lib/idTokenSpec.coffee
+++ b/test/lib/idTokenSpec.coffee
@@ -22,6 +22,7 @@ IDToken = require path.join cwd, 'lib/IDToken'
 IDTokenError = require path.join cwd, 'lib/IDTokenError'
 JWT = require 'anvil-connect-jwt'
 base64url = require 'base64url'
+nowSeconds = require(path.join cwd, 'lib/time-utils').nowSeconds
 
 
 
@@ -375,7 +376,7 @@ describe 'ID Token', ->
         payload =
           iss: 'https://your.authorization.server'
           sub: 'uuid'
-          exp: Date.now() - 1000
+          exp: nowSeconds(-1000)
           aud: 'https://your.client.app'
 
         jwt = (new IDToken payload).encode(privateKey)


### PR DESCRIPTION
The anvil-connect server switched `exp` and `iat` claims to be based on "seconds" instead of "milliseconds" (as it should according to the spec). This library needed to be updated to reflect this change or tokens were incorrectly flagged as "expired".

Note that I updated the default value function for the IDToken entity as well [here](https://github.com/christiansmith/anvil-connect-sdk/compare/master...tomkersten:ms_to_seconds?expand=1#diff-006edde22f2efbcbbdc1f843aeb87614R58). I mention this specifically just to confirm this is the behavior we'd want.